### PR TITLE
Fix main-is in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jroff",
   "version": "0.0.1",
   "description": "A man page parser for the web",
-  "main": "index.js",
+  "main": "dist/jroff.min.js",
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
Previously, I was getting a module not found error when I depended on this package.